### PR TITLE
fix rounding error in print_hardware_info()

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -642,7 +642,7 @@ print_tcp_ports() {
 print_hardware_info() {
 	if [ -x /usr/sbin/dmidecode ] && dmidecode | grep -q "SMBIOS.*present." ; then
 		echo -en "hardware\t: ";
-		colorcheck "$(echo $(($(awk "/MemT/ {print \$2}" /proc/meminfo)/1000000)))G RAM" 2;
+		colorcheck "$(awk '$1 == "MemTotal:" {printf("%.1f\n",$2/1024/1024);}' /proc/meminfo)GiB RAM" 2;
 		colorcheck "$(/bin/grep -c processor /proc/cpuinfo) CPU" 2;
 
 		if [ "$(dmidecode --type system|awk -F ":" '$1 == "\tManufacturer" {print $NF}')" = " VMware, Inc." ]; then


### PR DESCRIPTION
fixes an error in `print_hardware_info()`, causing less memory to be reported due to Bash's inability to properly round values.

In Bash, `3.7` will be rounded down to `3` m(

since `bc` is not always installed or available, we use `awk`.