### PR TITLE
suppress output of spawned ssh process in expect.sh

### DIFF
--- a/expect.sh
+++ b/expect.sh
@@ -8,7 +8,7 @@ trap {
 	stty rows $rows columns $cols < $spawn_out(slave,name)
 } WINCH
 
-spawn {*}$argv
+spawn -noecho {*}$argv
 expect {
 	eof { exit 1 }
 	timeout { puts "\n\nSorry, could not detect a valid prompt. Shelly is not available.\n" ; interact }


### PR DESCRIPTION
added -noecho to expect.sh to suppress the output of the spawn line.